### PR TITLE
Enum to Const Enum

### DIFF
--- a/either/index.ts
+++ b/either/index.ts
@@ -1,6 +1,6 @@
 import { Monad } from "@sweet-monads/interfaces";
 
-enum EitherType {
+const enum EitherType {
   Left = "Left",
   Right = "Right"
 }


### PR DESCRIPTION
# Changelog

1. Replaced usage of enum with const enum in order to probably improve some memory usage))

Just interesting your opinion on it.