### PR TITLE
`this` context is lost when using `fromNullable`

### DIFF
--- a/maybe/index.ts
+++ b/maybe/index.ts
@@ -68,13 +68,13 @@ export default class MaybeConstructor<T, S extends MaybeState = MaybeState> impl
   }
 
   static from<T>(v: T): Maybe<T> {
-    return this.just(v);
+    return MaybeConstructor.just(v);
   }
 
   static fromNullable<T>(v: T): Maybe<Exclude<T, null | undefined>> {
     return v !== null && v !== undefined
-      ? this.just(v as Exclude<T, null | undefined>)
-      : this.none<Exclude<T, null | undefined>>();
+      ? MaybeConstructor.just(v as Exclude<T, null | undefined>)
+      : MaybeConstructor.none<Exclude<T, null | undefined>>();
   }
 
   static none<T = never>(): Maybe<T> {


### PR DESCRIPTION
Hi! Thanks for the lib ❤️ 

Right now static methods `Maybe.fromNullable` and `Maybe.from` are exported using destructurization syntax which lead to lost context 

```ts
export const { merge, just, none, from, fromNullable, chain } = MaybeConstructor;
```

Example: 
```js
import { fromNullable } from '@sweet-monads/maybe';

fromNullable(42);
```

```sh
➜  test git:(master) ✗ node --experimental-modules index.mjs
(node:18306) ExperimentalWarning: The ESM module loader is experimental.
(node:18306) ExperimentalWarning: Conditional exports is an experimental feature. This feature could change at any time
file:///Users/seit/Documents/Projects/test/node_modules/@sweet-monads/maybe/esm/index.js:25
            ? this.just(v)
                   ^

TypeError: Cannot read property 'just' of undefined
    at fromNullable (file:///Users/seit/Documents/Projects/test/node_modules/@sweet-monads/maybe/esm/index.js:25:20)
    at file:///Users/seit/Documents/Projects/test/index.mjs:3:1
    at ModuleJob.run (internal/modules/esm/module_job.js:110:37)
    at async Loader.import (internal/modules/esm/loader.js:176:24)
```

<div>
    <img src="https://user-images.githubusercontent.com/26577190/117060924-39823b80-ad2a-11eb-99fc-f548c36d12a2.png" width="400" />
    <img src="https://user-images.githubusercontent.com/26577190/117060962-456dfd80-ad2a-11eb-8498-3588bb6d02cb.png" width="400" />
</div>

--- 

Honestly i don't know why tests are passing. Maybe this is somehow related to ts-jest transformation.
But I guess we might refer to `MaybeConstructor` instead of `this` inside static methods 🙂 