### PR TITLE
Added rust-like `unwrap()` for `Maybe` and `Either`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,9 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended"
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off"
+  }
 }

--- a/either/README.md
+++ b/either/README.md
@@ -477,6 +477,12 @@ const { value } = left<Error, number>(new Error()); // number | Error
 const { value } = left(new Error()); // Error
 ```
 
+```typescript
+right(2).unwrap() // number
+left(new TypeError()).unwrap() // throws value (TypeError)
+left(2).unwrap() // throws 2 (don't do this)
+```
+
 ## License
 
 MIT (c) Artem Kobzar see LICENSE file.

--- a/either/index.ts
+++ b/either/index.ts
@@ -4,7 +4,8 @@ import type {
   AsyncChainable,
   ClassImplements,
   MonadConstructor,
-  ApplicativeConstructor
+  ApplicativeConstructor,
+  Container
 } from "@sweet-monads/interfaces";
 
 const enum EitherType {
@@ -23,7 +24,8 @@ type StaticCheck = ClassImplements<
   typeof EitherConstructor,
   [MonadConstructor, ApplicativeConstructor, AsyncChainable<Either<any, any>>]
 >;
-class EitherConstructor<L, R, T extends EitherType = EitherType> implements AsyncMonad<R>, Alternative<T> {
+class EitherConstructor<L, R, T extends EitherType = EitherType>
+  implements AsyncMonad<R>, Alternative<T>, Container<R> {
   static chain<L, R, NR>(f: (v: R) => Promise<Either<never, NR>>): (m: Either<L, R>) => Promise<Either<L, NR>>;
   static chain<L, R, NL>(f: (v: R) => Promise<Either<NL, never>>): (m: Either<L, R>) => Promise<Either<NL | L, R>>;
   static chain<L, R, NL, NR>(f: (v: R) => Promise<Either<NL, NR>>): (m: Either<L, R>) => Promise<Either<NL | L, NR>>;
@@ -300,7 +302,7 @@ class EitherConstructor<L, R, T extends EitherType = EitherType> implements Asyn
   unwrap(): R {
     if (this.isRight()) return this.value;
 
-    throw this.value;
+    throw new Error("Either state is Left");
   }
 }
 

--- a/either/index.ts
+++ b/either/index.ts
@@ -97,7 +97,8 @@ class EitherConstructor<L, R, T extends EitherType = EitherType> implements Asyn
     ]
   ): Either<L1 | L2 | L3 | L4 | L5 | L6 | L7 | L8 | L9 | L10, [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10]>;
   static mergeInOne<L, R>(either: Array<Either<L, R>>): Either<L, R[]>;
-  static mergeInOne(eithers: Array<Either<unknown, unknown>>): Either<unknown, unknown[]> {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  static mergeInOne(eithers: Array<Either<unknown, unknown>>) {
     return eithers.reduce(
       (res: Either<unknown, Array<unknown>>, v) => res.chain(res => v.map(v => res.concat([v]))),
       EitherConstructor.right<unknown, Array<unknown>>([])

--- a/either/index.ts
+++ b/either/index.ts
@@ -21,6 +21,7 @@ function isWrappedFunction<A, B, L>(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type StaticCheck = ClassImplements<
   typeof EitherConstructor,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [MonadConstructor, ApplicativeConstructor, AsyncChainable<Either<any, any>>]
 >;
 class EitherConstructor<L, R, T extends EitherType = EitherType> implements AsyncMonad<R>, Alternative<T> {
@@ -96,7 +97,7 @@ class EitherConstructor<L, R, T extends EitherType = EitherType> implements Asyn
     ]
   ): Either<L1 | L2 | L3 | L4 | L5 | L6 | L7 | L8 | L9 | L10, [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10]>;
   static mergeInOne<L, R>(either: Array<Either<L, R>>): Either<L, R[]>;
-  static mergeInOne(eithers: Array<Either<unknown, unknown>>) {
+  static mergeInOne(eithers: Array<Either<unknown, unknown>>): Either<unknown, unknown[]> {
     return eithers.reduce(
       (res: Either<unknown, Array<unknown>>, v) => res.chain(res => v.map(v => res.concat([v]))),
       EitherConstructor.right<unknown, Array<unknown>>([])
@@ -170,7 +171,7 @@ class EitherConstructor<L, R, T extends EitherType = EitherType> implements Asyn
     ]
   ): Either<Array<L1 | L2 | L3 | L4 | L5 | L6 | L7 | L8 | L9 | L10>, [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10]>;
   static mergeInMany<L, R>(either: Array<Either<L, R>>): Either<L[], R[]>;
-  static mergeInMany(eithers: Array<Either<unknown, unknown>>) {
+  static mergeInMany(eithers: Array<Either<unknown, unknown>>): EitherConstructor<unknown[], unknown[], EitherType> {
     return eithers.reduce((res: EitherConstructor<Array<unknown>, Array<unknown>>, v): EitherConstructor<
       Array<unknown>,
       Array<unknown>
@@ -184,7 +185,7 @@ class EitherConstructor<L, R, T extends EitherType = EitherType> implements Asyn
     }, EitherConstructor.right<Array<unknown>, Array<unknown>>([]));
   }
 
-  static from<T>(v: T) {
+  static from<T>(v: T): Either<never, T> {
     return EitherConstructor.right(v);
   }
 

--- a/either/index.ts
+++ b/either/index.ts
@@ -21,7 +21,6 @@ function isWrappedFunction<A, B, L>(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type StaticCheck = ClassImplements<
   typeof EitherConstructor,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [MonadConstructor, ApplicativeConstructor, AsyncChainable<Either<any, any>>]
 >;
 class EitherConstructor<L, R, T extends EitherType = EitherType> implements AsyncMonad<R>, Alternative<T> {
@@ -97,7 +96,6 @@ class EitherConstructor<L, R, T extends EitherType = EitherType> implements Asyn
     ]
   ): Either<L1 | L2 | L3 | L4 | L5 | L6 | L7 | L8 | L9 | L10, [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10]>;
   static mergeInOne<L, R>(either: Array<Either<L, R>>): Either<L, R[]>;
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   static mergeInOne(eithers: Array<Either<unknown, unknown>>) {
     return eithers.reduce(
       (res: Either<unknown, Array<unknown>>, v) => res.chain(res => v.map(v => res.concat([v]))),

--- a/either/index.ts
+++ b/either/index.ts
@@ -293,8 +293,14 @@ class EitherConstructor<L, R, T extends EitherType = EitherType> implements Asyn
     return f(this.value as R);
   }
 
-  or(x: Either<L, R>) {
+  or(x: Either<L, R>): Either<L, R> {
     return this.isLeft() ? x : (this as Either<L, R>);
+  }
+
+  unwrap(): R {
+    if (this.isRight()) return this.value;
+
+    throw this.value;
   }
 }
 

--- a/interfaces/README.md
+++ b/interfaces/README.md
@@ -383,6 +383,21 @@ declare function sendToServer(value: number): Promise<IdentityMonad<void>>
 const value = await getAsyncValue().then(chain(sendToServer));
 ```
 
+### Container 
+
+Is a value wrapper, that allows to get value (if state of the container is valid), or throws error if not.
+
+Methods:
+
+##### `Container#unwrap`
+
+```typescript
+const lucky = Math.random() > 0.5 ? just(":)") : none();
+
+// Will either return ":)" or throw an error
+lucky.unwrap();
+```
+
 ## License
 
 MIT (c) Artem Kobzar see LICENSE file.

--- a/interfaces/container.d.ts
+++ b/interfaces/container.d.ts
@@ -1,0 +1,3 @@
+export interface Container<T> {
+  unwrap(): T;
+}

--- a/interfaces/index.d.ts
+++ b/interfaces/index.d.ts
@@ -7,3 +7,4 @@ export type { ClassImplements } from "./class-implements";
 export type { AsyncApplicative } from "./async-applicative";
 export type { Monad, MonadConstructor } from "./monad";
 export type { Applicative, ApplicativeConstructor } from "./applicative";
+export type { Container } from "./container";

--- a/iterator/index.ts
+++ b/iterator/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { MapOperation } from "./map-operation";
 import { FilterOperation } from "./filter-operation";
 import { IntermidiateOperation } from "./intermediate-operation";
@@ -5,10 +6,11 @@ import MaybeConstructor, { Maybe, just, none } from "@sweet-monads/maybe";
 
 type FromIterator<A, S extends Iterable<A> = Iterable<A>, T extends Iterable<A> = Iterable<A>> = (source: S) => T;
 
-const defaultFromIterator = function <I>(original: LazyIterator<I>): Array<I> {
+const defaultFromIterator = function <I>(original: Iterable<I>): Array<I> {
   return [...original];
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const id: any = (x: number) => x;
 
 export default class LazyIterator<I> implements Iterable<I> {
@@ -97,7 +99,7 @@ export default class LazyIterator<I> implements Iterable<I> {
     return LazyIterator.withOperation(this, this.isCycled, new MapOperation(x => fn(x), true));
   }
 
-  intersect(other: LazyIterator<I>) {
+  intersect(other: LazyIterator<I>): LazyIterator<I> {
     const existed = new Set<I>(other);
     return this.filter(value => existed.has(value));
   }
@@ -116,7 +118,7 @@ export default class LazyIterator<I> implements Iterable<I> {
     );
   }
 
-  prepend(item: I) {
+  prepend(item: I): LazyIterator<I> {
     return LazyIterator.from([item]).chain(this);
   }
 
@@ -129,20 +131,20 @@ export default class LazyIterator<I> implements Iterable<I> {
     return this.map(() => oldIterator[i--]);
   }
 
-  skip(n: number) {
+  skip(n: number): LazyIterator<I> {
     return this.filter(() => n === 0 || n-- <= 0);
   }
 
-  scan<A>(fn: (a: A, i: I) => A, accumulator: A) {
+  scan<A>(fn: (a: A, i: I) => A, accumulator: A): LazyIterator<A> {
     return this.map(value => (accumulator = fn(accumulator, value)));
   }
 
-  skipWhile(predicate: (i: I) => boolean) {
+  skipWhile(predicate: (i: I) => boolean): LazyIterator<I> {
     let hasBeenFalse = false;
     return this.filter(i => hasBeenFalse || (hasBeenFalse = !predicate(i)));
   }
 
-  slice(start = 0, end?: number) {
+  slice(start = 0, end?: number): LazyIterator<I> {
     let index = 0;
     return LazyIterator.withOperation(
       this,
@@ -464,11 +466,11 @@ export default class LazyIterator<I> implements Iterable<I> {
     return withoutMaybe ? result.value : result;
   }
 
-  product(this: LazyIterator<number>) {
+  product(this: LazyIterator<number>): number {
     return this.fold((res, a) => res * a, 1);
   }
 
-  sum(this: LazyIterator<number>) {
+  sum(this: LazyIterator<number>): number {
     return this.fold((sum, a) => sum + a, 0);
   }
 

--- a/iterator/index.ts
+++ b/iterator/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { MapOperation } from "./map-operation";
 import { FilterOperation } from "./filter-operation";
 import { IntermidiateOperation } from "./intermediate-operation";
@@ -10,7 +9,6 @@ const defaultFromIterator = function <I>(original: Iterable<I>): Array<I> {
   return [...original];
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const id: any = (x: number) => x;
 
 export default class LazyIterator<I> implements Iterable<I> {

--- a/maybe/README.md
+++ b/maybe/README.md
@@ -384,6 +384,12 @@ const newVal4 = v2.asyncChain(a => Promise.resolve(none()));
 const { value } = just(2); // number | undefined
 ```
 
+```typescript
+const value = just(2).unwrap(); // returns 2
+
+none().unwrap(); // Throws error
+```
+
 ## License
 
 MIT (c) Artem Kobzar see LICENSE file.

--- a/maybe/index.ts
+++ b/maybe/index.ts
@@ -4,7 +4,8 @@ import type {
   AsyncChainable,
   ClassImplements,
   MonadConstructor,
-  ApplicativeConstructor
+  ApplicativeConstructor,
+  Container
 } from "@sweet-monads/interfaces";
 
 const enum MaybeState {
@@ -27,7 +28,8 @@ type StaticCheck = ClassImplements<
   typeof MaybeConstructor,
   [MonadConstructor, ApplicativeConstructor, AsyncChainable<Maybe<any>>]
 >;
-export default class MaybeConstructor<T, S extends MaybeState = MaybeState> implements AsyncMonad<T>, Alternative<T> {
+export default class MaybeConstructor<T, S extends MaybeState = MaybeState>
+  implements AsyncMonad<T>, Alternative<T>, Container<T> {
   static chain<A, B>(f: (v: A) => Promise<Maybe<B>>) {
     return (m: Maybe<A>): Promise<Maybe<B>> => m.asyncChain(f);
   }

--- a/maybe/index.ts
+++ b/maybe/index.ts
@@ -25,7 +25,6 @@ function isWrappedAsyncFunction<A, B>(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type StaticCheck = ClassImplements<
   typeof MaybeConstructor,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [MonadConstructor, ApplicativeConstructor, AsyncChainable<Maybe<any>>]
 >;
 export default class MaybeConstructor<T, S extends MaybeState = MaybeState> implements AsyncMonad<T>, Alternative<T> {

--- a/maybe/index.ts
+++ b/maybe/index.ts
@@ -162,8 +162,14 @@ export default class MaybeConstructor<T, S extends MaybeState = MaybeState> impl
     return Promise.resolve(MaybeConstructor.none<V>());
   }
 
-  or(x: Maybe<T>) {
+  or(x: Maybe<T>): Maybe<T> {
     return this.isNone() ? x : (this as Maybe<T>);
+  }
+
+  unwrap(): T {
+    if (this.isJust()) return this.value;
+
+    throw new Error("Value is None");
   }
 }
 

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -60,4 +60,12 @@ describe("Either", () => {
     const newVal3 = fn2.asyncApply(v1); // Promise<Either<Error, number>.Left> with value new Error()
     const newVal4 = fn2.asyncApply(v2); // Promise<Either<Error, number>.Left> with value new Error() */
   });
+
+  test("unwrap", () => {
+    const v1 = right<Error, number>(2);
+    const v2 = left<Error, number>(new Error());
+
+    expect(v1.unwrap()).toBe(2);
+    expect(v2.unwrap).toThrow(new Error());
+  });
 });

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -66,6 +66,6 @@ describe("Either", () => {
     const v2 = left<Error, number>(new Error());
 
     expect(v1.unwrap()).toBe(2);
-    expect(v2.unwrap).toThrow(new Error());
+    expect(() => v2.unwrap()).toThrow(new Error());
   });
 });

--- a/tests/maybe.test.ts
+++ b/tests/maybe.test.ts
@@ -23,4 +23,12 @@ describe("Maybe", () => {
         expect(nil.isNone()).toBe(option === null || option === undefined);
       })
     ));
+
+  test("unwrap", () => {
+    const v1 = just(2);
+    const v2 = none();
+
+    expect(v1.unwrap()).toBe(2);
+    expect(() => v2.unwrap()).toThrow(new Error("Value is None"));
+  });
 });


### PR DESCRIPTION
## Why?

Better escape hatch than `.value`

## Usage

```typescript
function getUser(id: string): Either<UserError, User>;
const value = getUser(11).unwrap().name;
```

## What else

- Fixed compiler and linter errors
